### PR TITLE
Revise dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/scripts/reformat.py
+++ b/scripts/reformat.py
@@ -2,32 +2,65 @@ import pandas as pd
 import numpy as np
 import os
 
+
 def reformat(df):
     # Extracting and converting data from the dataframe
     converted_data = {
-        'total_energy': [float(entry['energy']['$numberDouble']) for entry in df['outputs']],
-        'forces': [[[float(force.get('$numberDouble', 0)) for force in l]for l in entry['forces']] for entry in df["outputs"]],
-        'stresses': [[float(stress['$numberDouble']) if isinstance(stress, dict) and '$numberDouble' in stress else 0 for stress in entry['stress']] for entry in df['outputs']],
-        'atoms':[
-                    {
-                    'lattice_mat':[[float(l['$numberDouble']) for l in list] for list in entry['lattice']['matrix']],
-                    'coords':[[float(j['$numberDouble']) for j in i['xyz']] for i in entry['sites']], 
-                    'abc':[float(entry['lattice']['a']['$numberDouble']), float(entry['lattice']['b']['$numberDouble']), float(entry['lattice']['c']['$numberDouble'])],
-                    'elements':[i['species'][0]['element'] for i in entry['sites']],
-                    'angles':[float(entry['lattice']['alpha']['$numberDouble']), float(entry['lattice']['beta']['$numberDouble']), float(entry['lattice']['gamma']['$numberDouble'])],
-                    'cartesian': False,
-                    'props': ['']
-                    } 
-                    for entry in df["structure"]
-                ]
+        "total_energy": [
+            float(entry["energy"]["$numberDouble"]) for entry in df["outputs"]
+        ],
+        "forces": [
+            [
+                [float(force.get("$numberDouble", 0)) for force in l]
+                for l in entry["forces"]
+            ]
+            for entry in df["outputs"]
+        ],
+        "stresses": [
+            [
+                float(stress["$numberDouble"])
+                if isinstance(stress, dict) and "$numberDouble" in stress
+                else 0
+                for stress in entry["stress"]
+            ]
+            for entry in df["outputs"]
+        ],
+        "atoms": [
+            {
+                "lattice_mat": [
+                    [float(l["$numberDouble"]) for l in list]
+                    for list in entry["lattice"]["matrix"]
+                ],
+                "coords": [
+                    [float(j["$numberDouble"]) for j in i["xyz"]]
+                    for i in entry["sites"]
+                ],
+                "abc": [
+                    float(entry["lattice"]["a"]["$numberDouble"]),
+                    float(entry["lattice"]["b"]["$numberDouble"]),
+                    float(entry["lattice"]["c"]["$numberDouble"]),
+                ],
+                "elements": [i["species"][0]["element"] for i in entry["sites"]],
+                "angles": [
+                    float(entry["lattice"]["alpha"]["$numberDouble"]),
+                    float(entry["lattice"]["beta"]["$numberDouble"]),
+                    float(entry["lattice"]["gamma"]["$numberDouble"]),
+                ],
+                "cartesian": False,
+                "props": [""],
+            }
+            for entry in df["structure"]
+        ],
     }
     converted_df = pd.DataFrame(converted_data)
-    converted_df['total_energy'] = converted_df['total_energy'].astype(float)
-    converted_df.to_csv('/Users/insomni_.ak/Documents/Machine Learning/MoTaNbTi/input/MoTaNbTi_1.csv', index=False)
+    converted_df["total_energy"] = converted_df["total_energy"].astype(float)
+    converted_df.to_csv("data/MoTaNbTi/MoTaNbTi_1.csv", index=False)
     return converted_df
 
+
 if __name__ == "__main__":
-    with open('/Users/insomni_.ak/Documents/Machine Learning/MoTaNbTi/dump/data/output.json', 'r') as file:
+    # first dump bson data to json
+    with open("data/MoTaNbTi/output.json", "r") as file:
         data = file.read().splitlines()
     dfs = [pd.read_json(json_str, lines=True) for json_str in data]
     df = pd.concat(dfs, ignore_index=True)

--- a/scripts/reformat.py
+++ b/scripts/reformat.py
@@ -3,66 +3,71 @@ import numpy as np
 import os
 
 
+def extract_data(entry):
+    return entry
+
+
 def reformat(df):
     # Extracting and converting data from the dataframe
-    converted_data = {
-        "total_energy": [
-            float(entry["energy"]["$numberDouble"]) for entry in df["outputs"]
-        ],
-        "forces": [
-            [
-                [float(force.get("$numberDouble", 0)) for force in l]
-                for l in entry["forces"]
-            ]
-            for entry in df["outputs"]
-        ],
-        "stresses": [
-            [
-                float(stress["$numberDouble"])
-                if isinstance(stress, dict) and "$numberDouble" in stress
-                else 0
-                for stress in entry["stress"]
-            ]
-            for entry in df["outputs"]
-        ],
-        "atoms": [
-            {
-                "lattice_mat": [
-                    [float(l["$numberDouble"]) for l in list]
-                    for list in entry["lattice"]["matrix"]
-                ],
-                "coords": [
-                    [float(j["$numberDouble"]) for j in i["xyz"]]
-                    for i in entry["sites"]
-                ],
-                "abc": [
-                    float(entry["lattice"]["a"]["$numberDouble"]),
-                    float(entry["lattice"]["b"]["$numberDouble"]),
-                    float(entry["lattice"]["c"]["$numberDouble"]),
-                ],
-                "elements": [i["species"][0]["element"] for i in entry["sites"]],
-                "angles": [
-                    float(entry["lattice"]["alpha"]["$numberDouble"]),
-                    float(entry["lattice"]["beta"]["$numberDouble"]),
-                    float(entry["lattice"]["gamma"]["$numberDouble"]),
-                ],
-                "cartesian": False,
-                "props": [""],
-            }
-            for entry in df["structure"]
-        ],
-    }
+    id = [entry["$oid"] for entry in df["_id"]]
+    split_tag = df["tag"].values
+    energy = [float(entry["energy"]["$numberDouble"]) for entry in df["outputs"]]
+    forces = [
+        [[float(force.get("$numberDouble", 0)) for force in l] for l in entry["forces"]]
+        for entry in df["outputs"]
+    ]
+    stress = [
+        [
+            float(stress["$numberDouble"])
+            if isinstance(stress, dict) and "$numberDouble" in stress
+            else 0
+            for stress in entry["stress"]
+        ]
+        for entry in df["outputs"]
+    ]
+    atoms = [
+        {
+            "lattice_mat": [
+                [float(l["$numberDouble"]) for l in list]
+                for list in entry["lattice"]["matrix"]
+            ],
+            "coords": [
+                [float(j["$numberDouble"]) for j in i["xyz"]] for i in entry["sites"]
+            ],
+            "abc": [
+                float(entry["lattice"]["a"]["$numberDouble"]),
+                float(entry["lattice"]["b"]["$numberDouble"]),
+                float(entry["lattice"]["c"]["$numberDouble"]),
+            ],
+            "elements": [i["species"][0]["element"] for i in entry["sites"]],
+            "angles": [
+                float(entry["lattice"]["alpha"]["$numberDouble"]),
+                float(entry["lattice"]["beta"]["$numberDouble"]),
+                float(entry["lattice"]["gamma"]["$numberDouble"]),
+            ],
+            "cartesian": False,
+            "props": [""],
+        }
+        for entry in df["structure"]
+    ]
+
+    converted_data = dict(
+        id=id,
+        split_tag=split_tag,
+        calc_type=df.group.values,
+        description=df.description.values,
+        energy=energy,
+        forces=forces,
+        stress=stress,
+        atoms=atoms,
+    )
     converted_df = pd.DataFrame(converted_data)
-    converted_df["total_energy"] = converted_df["total_energy"].astype(float)
-    converted_df.to_csv("data/MoTaNbTi/MoTaNbTi_1.csv", index=False)
+    converted_df["energy"] = converted_df["energy"].astype(float)
+    converted_df.to_json("data/MoTaNbTi/MoTaNbTi.jsonl", lines=True, orient="records")
     return converted_df
 
 
 if __name__ == "__main__":
-    # first dump bson data to json
-    with open("data/MoTaNbTi/output.json", "r") as file:
-        data = file.read().splitlines()
-    dfs = [pd.read_json(json_str, lines=True) for json_str in data]
-    df = pd.concat(dfs, ignore_index=True)
-
+    # first dump bson data to json-lines
+    df = pd.read_json("data/MoTaNbTi/output.json", lines=True)
     df_modified = reformat(df)

--- a/scripts/reformat.py
+++ b/scripts/reformat.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import numpy as np
+import os
+
+def reformat(df):
+    # Extracting and converting data from the dataframe
+    converted_data = {
+        'total_energy': [float(entry['energy']['$numberDouble']) for entry in df['outputs']],
+        'forces': [[[float(force.get('$numberDouble', 0)) for force in l]for l in entry['forces']] for entry in df["outputs"]],
+        'stresses': [[float(stress['$numberDouble']) if isinstance(stress, dict) and '$numberDouble' in stress else 0 for stress in entry['stress']] for entry in df['outputs']],
+        'atoms':[
+                    {
+                    'lattice_mat':[[float(l['$numberDouble']) for l in list] for list in entry['lattice']['matrix']],
+                    'coords':[[float(j['$numberDouble']) for j in i['xyz']] for i in entry['sites']], 
+                    'abc':[float(entry['lattice']['a']['$numberDouble']), float(entry['lattice']['b']['$numberDouble']), float(entry['lattice']['c']['$numberDouble'])],
+                    'elements':[i['species'][0]['element'] for i in entry['sites']],
+                    'angles':[float(entry['lattice']['alpha']['$numberDouble']), float(entry['lattice']['beta']['$numberDouble']), float(entry['lattice']['gamma']['$numberDouble'])],
+                    'cartesian': False,
+                    'props': ['']
+                    } 
+                    for entry in df["structure"]
+                ]
+    }
+    converted_df = pd.DataFrame(converted_data)
+    converted_df['total_energy'] = converted_df['total_energy'].astype(float)
+    converted_df.to_csv('/Users/insomni_.ak/Documents/Machine Learning/MoTaNbTi/input/MoTaNbTi_1.csv', index=False)
+    return converted_df
+
+if __name__ == "__main__":
+    with open('/Users/insomni_.ak/Documents/Machine Learning/MoTaNbTi/dump/data/output.json', 'r') as file:
+        data = file.read().splitlines()
+    dfs = [pd.read_json(json_str, lines=True) for json_str in data]
+    df = pd.concat(dfs, ignore_index=True)
+
+    df_modified = reformat(df)


### PR DESCRIPTION
Basit - I added your data extraction script and modified it a bit to include a few extra metadata fields that we might find useful

I put the raw data files under a directory in the repository root `data/MoTaNbTi/output.json`, then run the extraction script `python scripts/reformat.py` which has the relative paths hardcoded.

this script produces the file `data/MoTaNbTi/MoTaNbNi.jsonl`, which you can load as a nfflr force field dataset like this

```python
import nfflr
dataset = nfflr.AtomsDataset(
    "data/MoTaNbTi/MoTaNbTi.jsonl", 
    id_tag="id", 
    group_ids=True, 
    target="energy_and_forces", 
    energy_units="eV"
)
```

One thing I have to still fix is the train/val/test splitting. The dataset comes with predefined train/test split but loading the dataset like above still uses random splitting, ignoring those predefined labels

Also, I'm not sure whether/how to group calculations together for train/val, there might be some information in the description field we want to look at